### PR TITLE
added client identification for remote executors

### DIFF
--- a/server/knex/migrations/20220730111700_remote_machine_cert_serial.js
+++ b/server/knex/migrations/20220730111700_remote_machine_cert_serial.js
@@ -1,0 +1,13 @@
+const MACHINES_TABLE = 'job_executors';
+const CERT_COL = 'cert_serial';
+
+
+exports.up = (knex, Promise) => (async () => {
+    await knex.schema.table(MACHINES_TABLE, table => {
+        table.string(CERT_COL).notNullable().defaultTo("");
+    });
+})();
+
+exports.down = (knex, Promise) => (async () => {
+    await knex.schema.table(MACHINES_TABLE, t => t.dropColumn(CERT_COL));
+});

--- a/server/lib/task-events.js
+++ b/server/lib/task-events.js
@@ -30,11 +30,19 @@ function getSuccessEventType(runId) {
     return `run/${runId}/${EventTypes.SUCCESS}`;
 }
 
+/** extracts the string representation of run id from an event type (OUTPUT, STOP, FAIL, SUCCESS only) */
+function getRunIdFromEventType(type) {
+    const etRe = RegExp('run\/(?<runId>[0-9]+)\/', 'g');
+    let match = etRe.exec(type);
+    return match === null ? null : match.groups.runId;
+}
+
 module.exports = {
     EventTypes,
     getOutputEventType,
     getStopEventType,
     getFailEventType,
     getSuccessEventType,
-    emitter
+    emitter,
+    getRunIdFromEventType
 }

--- a/server/models/job-execs.js
+++ b/server/models/job-execs.js
@@ -68,7 +68,13 @@ async function create(context, executor) {
         // and created on executor type update
 
         try {
-            await remoteCert.createRemoteExecutorCertificate(filteredEntity)
+            const certHexSerial = await remoteCert.createRemoteExecutorCertificate(filteredEntity);
+            if (certHexSerial === null) {
+                throw new Error();
+            }
+
+            const certDecSerialString = BigInt(`0x${certHexSerial}`).toString();
+            await tx(EXEC_TABLE).update({ 'cert_serial': certDecSerialString }).where('id', id);
         }
         catch {
             remoteCert.tryRemoveCertificate(filteredEntity.id);


### PR DESCRIPTION
it is enforced now that a remote executor pushes updates only of runs that were assigned to that executor

removal of an executor results in an error